### PR TITLE
Remove "gcc" hardcoding to fix broken build on windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,6 @@
 				<extensions>true</extensions>
 				<configuration>
 					<c>
-						<name>gcc</name>
 						<includes>
 							<include>**/*.c</include>
 						</includes>
@@ -66,7 +65,6 @@
 						</options>
 					</c>
 					<linker>
-						<name>gcc</name>
 						<options>
 							<option>${architecture.option}</option>
 							<option>${subsystem.option}</option>


### PR DESCRIPTION
Removing hardcoded "gcc" in pom.xml. This makes the project build out-of-the-box with "mvn install" on windows, provided that the Visual Studio command prompt have been properly set up in advance.