### PR TITLE
Add tests for calling JNI code and improve the JNI call functionality 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>1.149</version>
+		<version>9.0.0</version>
 		<relativePath />
 	</parent>
 
@@ -97,6 +97,10 @@
 		<url>http://jenkins.imagej.net/job/SLIM-curve/</url>
 	</ciManagement>
 
+	<properties>
+		<nar-maven-plugin.version>3.3.0</nar-maven-plugin.version>
+	</properties>
+
 	<repositories>
 		<!-- NB: for project parent -->
 		<repository>
@@ -109,22 +113,23 @@
 		<dependency>
 			<groupId>org.scijava</groupId>
 			<artifactId>native-lib-loader</artifactId>
-			<version>2.0.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>${nar.groupId}</groupId>
+				<groupId>com.github.maven-nar</groupId>
 				<artifactId>nar-maven-plugin</artifactId>
-				<version>${nar.version}</version>
 				<extensions>true</extensions>
 				<configuration>
 					<c>
-						<includes>
-							<include>**/*.c</include>
-						</includes>
 						<options>
 							<option>-I${JAVA_HOME}/include</option>
 							<option>${java.os.include}</option>
@@ -143,6 +148,7 @@
 					<libraries>
 						<library>
 							<type>shared</type>
+							<narSystemPackage>loci.slim</narSystemPackage>
 						</library>
 					</libraries>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,10 @@
 	<description>A package for exponential curve fitting of combined spectral lifetime image data.</description>
 	<url>https://slim-curve.github.io/</url>
 	<inceptionYear>2010</inceptionYear>
-
+	<organization>
+		<name>SLIM Curve</name>
+		<url>https://github.com/slim-curve</url>
+	</organization>
 	<licenses>
 		<license>
 			<name>GNU General Public License v3+</name>
@@ -30,10 +33,77 @@
 		</license>
 	</licenses>
 
-	<organization>
-		<name>SLIM Curve</name>
-		<url>https://github.com/slim-curve</url>
-	</organization>
+	<developers>
+		<developer>
+			<id>paulbarber</id>
+			<name>Paul Barber</name>
+			<email>Paul.Barber@rob.ox.ac.uk</email>
+			<url>http://users.ox.ac.uk/~raob0009/</url>
+			<organization>Cancer Research UK and Medical Research Council Oxford Institute for Radiation Oncology</organization>
+			<organizationUrl>http://www.rob.ox.ac.uk/</organizationUrl>
+			<roles>
+				<role>architect</role>
+				<role>developer</role>
+			</roles>
+			<timezone>+0</timezone>
+		</developer>
+		<developer>
+			<id>grislis</id>
+			<name>Aivar Grislis</name>
+			<url>http://loci.wisc.edu/people/aivar-grislis</url>
+			<organization>UW-Madison LOCI</organization>
+			<organizationUrl>http://loci.wisc.edu/</organizationUrl>
+			<roles>
+				<role>developer</role>
+			</roles>
+			<timezone>-6</timezone>
+		</developer>
+		<developer>
+			<id>ctrueden</id>
+			<name>Curtis Rueden</name>
+			<email>ctrueden@wisc.edu</email>
+			<url>http://loci.wisc.edu/people/curtis-rueden</url>
+			<organization>UW-Madison LOCI</organization>
+			<organizationUrl>http://loci.wisc.edu/</organizationUrl>
+			<roles>
+				<role>architect</role>
+			</roles>
+			<timezone>-6</timezone>
+		</developer>
+	</developers>
+
+	<mailingLists>
+		<mailingList>
+			<name>SLIM Curve</name>
+			<subscribe>http://imagej.net/mailman/listinfo/slim-curve</subscribe>
+			<unsubscribe>http://imagej.net/mailman/listinfo/slim-curve</unsubscribe>
+			<post>slim-curve@imagej.net</post>
+			<archive>http://imagej.net/pipermail/slim-curve/</archive>
+		</mailingList>
+	</mailingLists>
+
+	<scm>
+		<connection>scm:git:git://github.com/uw-loci/slim-curve</connection>
+		<developerConnection>scm:git:git@github.com:uw-loci/slim-curve</developerConnection>
+		<tag>HEAD</tag>
+		<url>https://github.com/uw-loci/slim-curve</url>
+	</scm>
+	<issueManagement>
+		<system>GitHub Issues</system>
+		<url>https://github.com/slim-curve/slim-curve/issues</url>
+	</issueManagement>
+	<ciManagement>
+		<system>Jenkins</system>
+		<url>http://jenkins.imagej.net/job/SLIM-curve/</url>
+	</ciManagement>
+
+	<repositories>
+		<!-- NB: for project parent -->
+		<repository>
+			<id>imagej.public</id>
+			<url>http://maven.imagej.net/content/groups/public</url>
+		</repository>
+	</repositories>
 
 	<dependencies>
 		<dependency>
@@ -125,79 +195,4 @@ University of Wisconsin-Madison.</organizationName>
 			</plugin>
 		</plugins>
 	</build>
-
-	<developers>
-		<developer>
-			<id>paulbarber</id>
-			<name>Paul Barber</name>
-			<email>Paul.Barber@rob.ox.ac.uk</email>
-			<url>http://users.ox.ac.uk/~raob0009/</url>
-			<organization>Cancer Research UK and Medical Research Council Oxford Institute for Radiation Oncology</organization>
-			<organizationUrl>http://www.rob.ox.ac.uk/</organizationUrl>
-			<roles>
-				<role>architect</role>
-				<role>developer</role>
-			</roles>
-			<timezone>+0</timezone>
-		</developer>
-		<developer>
-			<id>grislis</id>
-			<name>Aivar Grislis</name>
-			<url>http://loci.wisc.edu/people/aivar-grislis</url>
-			<organization>UW-Madison LOCI</organization>
-			<organizationUrl>http://loci.wisc.edu/</organizationUrl>
-			<roles>
-				<role>developer</role>
-			</roles>
-			<timezone>-6</timezone>
-		</developer>
-		<developer>
-			<id>ctrueden</id>
-			<name>Curtis Rueden</name>
-			<email>ctrueden@wisc.edu</email>
-			<url>http://loci.wisc.edu/people/curtis-rueden</url>
-			<organization>UW-Madison LOCI</organization>
-			<organizationUrl>http://loci.wisc.edu/</organizationUrl>
-			<roles>
-				<role>architect</role>
-			</roles>
-			<timezone>-6</timezone>
-		</developer>
-	</developers>
-
-	<issueManagement>
-		<system>GitHub Issues</system>
-		<url>https://github.com/slim-curve/slim-curve/issues</url>
-	</issueManagement>
-
-	<ciManagement>
-		<system>Jenkins</system>
-		<url>http://jenkins.imagej.net/job/SLIM-curve/</url>
-	</ciManagement>
-
-	<mailingLists>
-		<mailingList>
-			<name>SLIM Curve</name>
-			<subscribe>http://imagej.net/mailman/listinfo/slim-curve</subscribe>
-			<unsubscribe>http://imagej.net/mailman/listinfo/slim-curve</unsubscribe>
-			<post>slim-curve@imagej.net</post>
-			<archive>http://imagej.net/pipermail/slim-curve/</archive>
-		</mailingList>
-	</mailingLists>
-
-	<scm>
-		<connection>scm:git:git://github.com/uw-loci/slim-curve</connection>
-		<developerConnection>scm:git:git@github.com:uw-loci/slim-curve</developerConnection>
-		<tag>HEAD</tag>
-		<url>https://github.com/uw-loci/slim-curve</url>
-	</scm>
-
-	<repositories>
-		<!-- NB: for project parent -->
-		<repository>
-			<id>imagej.public</id>
-			<url>http://maven.imagej.net/content/groups/public</url>
-		</repository>
-	</repositories>
-
 </project>

--- a/src/main/c/EcfWrapper.c
+++ b/src/main/c/EcfWrapper.c
@@ -27,6 +27,30 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+
+noise_type getNoiseModels (int val)
+{  // This is from TRI2 and must match the noise models, between TRI2 ui and     SLIM Curve - This is not a good thing to have! TRI2 should save the SLIM Cu    rve type
+
+    switch (val)
+    {
+        case 1:
+            return NOISE_GAUSSIAN_FIT;
+            break;
+        case 2:
+            return NOISE_POISSON_DATA;
+            break;
+        case 3:
+            return NOISE_POISSON_FIT;
+            break;
+        case 4:
+            return NOISE_MLE;
+            break;
+        default:
+            return NOISE_POISSON_FIT;
+            break;
+    }
+}
+
 /*
  * Rapid Lifetime Determination fit method.
  * 
@@ -56,7 +80,7 @@ int RLD_fit(
 		int fit_end,
 		double instr[],
 		int n_instr,
-		int noise,//noise_type noise,
+		int noise,
 		double sig[],
 		double *z,
 		double *a,
@@ -65,6 +89,7 @@ int RLD_fit(
 		double *chi_square,
 		double chi_square_target
 		) {
+	noise_type nt_noise = getNoiseModels(noise);
 	int n_data = fit_end + 1;
 	float x_inc_float = (float) x_inc;
 	float *y_float = (float *)malloc((size_t) n_data * sizeof(float));
@@ -103,7 +128,7 @@ int RLD_fit(
 			fit_end,
 			instr_float,
 			n_instr,
-			NOISE_POISSON_FIT,//TODO: hardcoded value
+			nt_noise,
 			sig_float,
 			&z_float,
 			&a_float,
@@ -159,7 +184,7 @@ int LMA_fit(
 		int fit_end,
 		double instr[],
 		int n_instr,
-		int noise,//noise_type noise,
+		int noise,
 		double sig[],
 		double param[],
 		int param_free[],
@@ -170,10 +195,10 @@ int LMA_fit(
 		double chi_square_delta
 		) {
 
+	noise_type nt_noise = getNoiseModels(noise);
 	restrain_type restrain = ECF_RESTRAIN_DEFAULT;
 	int chi_square_percent = 95;
-
-	int n_data = fit_end + 1;
+	int n_data = fit_end + 1; 
 	float *y_float = (float *)malloc((size_t) n_data * sizeof(float));
 	float *sig_float = (float *)malloc((size_t) n_data * sizeof(float));
 	float *instr_float = 0;
@@ -211,7 +236,7 @@ int LMA_fit(
 			param_float[1] = (float) param[2]; // a
 			param_float[2] = (float) param[3]; // tau
 			break;
-		case 4:
+		case 4: //TODO: fix these indices
 			// stretched exponential fit
 			param_float[0] = (float) param[1]; // z
 			param_float[1] = (float) param[2]; // a
@@ -247,7 +272,6 @@ int LMA_fit(
 	else {
 		fitfunc = GCI_multiexp_tau;
 	}
-
 	return_value = GCI_marquardt_fitting_engine(
 			(float) x_inc,
 			y_float,
@@ -256,8 +280,7 @@ int LMA_fit(
 			fit_end,
 			instr_float,
 			n_instr,
-			//noise,
-			NOISE_POISSON_FIT,
+			nt_noise,
 			sig_float,
 			param_float,
 			param_free,
@@ -327,6 +350,7 @@ int LMA_fit(
 			param[7] = (double) param_float[6]; // tau3
 			break;
 	}
+
 	free(param_float);
     
 	free(residuals_float);

--- a/src/main/c/EcfWrapper.c
+++ b/src/main/c/EcfWrapper.c
@@ -56,7 +56,7 @@ int RLD_fit(
 		int fit_end,
 		double instr[],
 		int n_instr,
-		noise_type noise,
+		int noise,//noise_type noise,
 		double sig[],
 		double *z,
 		double *a,
@@ -65,8 +65,7 @@ int RLD_fit(
 		double *chi_square,
 		double chi_square_target
 		) {
-
-	int n_data = fit_end;
+	int n_data = fit_end + 1;
 	float x_inc_float = (float) x_inc;
 	float *y_float = (float *)malloc((size_t) n_data * sizeof(float));
 	float *sig_float = (float *)malloc((size_t) n_data * sizeof(float));
@@ -79,15 +78,14 @@ int RLD_fit(
 	float chi_square_float = (float) *chi_square;
 	float chi_square_target_float = (float) chi_square_target;
 	int return_value;
-	int i;
 
-	for (i = 0; i < n_data; ++i) {
+	int i;
+	for (i = 0; i < n_data; i++) {
 		y_float[i] = (float) y[i];
 		sig_float[i] = ( sig ? (float) sig[i] : 1.0f );
 	}
 
 	if (instr) {
-		int i;
 		instr_float = (float *)malloc((size_t) n_instr * sizeof(float));
 		for (i = 0; i < n_instr; ++i) {
 			instr_float[i] = (float) instr[i];
@@ -97,7 +95,7 @@ int RLD_fit(
 	if (fitted) {
 		fitted_float = (float*)malloc((size_t) n_data * sizeof(float));
 	}
-
+	
 	return_value =  GCI_triple_integral_fitting_engine(
 			x_inc_float,
 			y_float,
@@ -105,7 +103,7 @@ int RLD_fit(
 			fit_end,
 			instr_float,
 			n_instr,
-			noise,
+			NOISE_POISSON_FIT,//TODO: hardcoded value
 			sig_float,
 			&z_float,
 			&a_float,
@@ -115,7 +113,6 @@ int RLD_fit(
 			&chi_square_float,
 			chi_square_target_float
 			);
-
 	*z          = (double) z_float;
 	*a          = (double) a_float;
 	*tau        = (double) tau_float;
@@ -128,14 +125,9 @@ int RLD_fit(
 		free(instr_float);
 	}
 	if (fitted_float) {
-		int i;
-		for (i = 0; i < n_data; ++i) {
-			fitted[i] = (double) fitted_float[i];
-		}
 		free(fitted_float);
 	}
 	free(residuals_float);
-
 	return return_value;
 }
 
@@ -167,7 +159,7 @@ int LMA_fit(
 		int fit_end,
 		double instr[],
 		int n_instr,
-		noise_type noise,
+		int noise,//noise_type noise,
 		double sig[],
 		double param[],
 		int param_free[],
@@ -181,7 +173,7 @@ int LMA_fit(
 	restrain_type restrain = ECF_RESTRAIN_DEFAULT;
 	int chi_square_percent = 95;
 
-	int n_data = fit_end;
+	int n_data = fit_end + 1;
 	float *y_float = (float *)malloc((size_t) n_data * sizeof(float));
 	float *sig_float = (float *)malloc((size_t) n_data * sizeof(float));
 	float *instr_float = 0;
@@ -195,7 +187,6 @@ int LMA_fit(
 	void (*fitfunc)(float, float [], float *, float[], int) = NULL;
 	int return_value;
 	int i;
-
 	for (i = 0; i < n_data; ++i) {
 		y_float[i] = (float) y[i];
 		sig_float[i] = ( sig ? (float) sig[i] : 1.0f );
@@ -210,7 +201,7 @@ int LMA_fit(
 	}
 
 	if (fitted) {
-		fitted_float = (float*)malloc((size_t) n_data * sizeof(float));
+		fitted_float = (float*)malloc((size_t) n_data * sizeof(float)); 
 	}
 	param_float = (float *)malloc((size_t) n_param * sizeof(float));
 	switch (n_param) {
@@ -265,7 +256,8 @@ int LMA_fit(
 			fit_end,
 			instr_float,
 			n_instr,
-			noise,
+			//noise,
+			NOISE_POISSON_FIT,
 			sig_float,
 			param_float,
 			param_free,
@@ -281,7 +273,6 @@ int LMA_fit(
 			(float) chi_square_target,
 			(float) chi_square_delta,
 			chi_square_percent);
-
 	*chi_square = (double) chi_square_float;
 
 	free(y_float);
@@ -291,12 +282,9 @@ int LMA_fit(
 		free(instr_float);
 	}
 	if (fitted_float) {
-		int i;
-		for (i = 0; i < n_data; ++i) {
-			fitted[i] = (double) fitted_float[i];
-		}
 		free(fitted_float);
 	}
+	
 	switch (n_param) {
 		case 3:
 			// single exponential fit

--- a/src/main/c/EcfWrapper.c
+++ b/src/main/c/EcfWrapper.c
@@ -142,17 +142,18 @@ int RLD_fit(
 	*a          = (double) a_float;
 	*tau        = (double) tau_float;
 	*chi_square = (double) chi_square_float;
-    
-	free(y_float);
-	free(sig_float);
-
+   	if (y_float) 
+		free(y_float);
+	if (sig_float)
+		free(sig_float);
 	if (instr_float) {
 		free(instr_float);
 	}
 	if (fitted_float) {
 		free(fitted_float);
 	}
-	free(residuals_float);
+	if (residuals_float)
+		free(residuals_float);
 	return return_value;
 }
 
@@ -214,9 +215,8 @@ int LMA_fit(
 	int i;
 	for (i = 0; i < n_data; ++i) {
 		y_float[i] = (float) y[i];
-		sig_float[i] = ( sig ? (float) sig[i] : 1.0f );
+		sig_float[i] = ( sig ? (float) sig[i] : 1.0f ); 
 	}
-
 	if (instr) {
 		int i;
 		instr_float = (float *)malloc((size_t) n_instr * sizeof(float));
@@ -236,7 +236,7 @@ int LMA_fit(
 			param_float[1] = (float) param[2]; // a
 			param_float[2] = (float) param[3]; // tau
 			break;
-		case 4: //TODO: fix these indices
+		case 4: 
 			// stretched exponential fit
 			param_float[0] = (float) param[1]; // z
 			param_float[1] = (float) param[2]; // a
@@ -272,6 +272,7 @@ int LMA_fit(
 	else {
 		fitfunc = GCI_multiexp_tau;
 	}
+
 	return_value = GCI_marquardt_fitting_engine(
 			(float) x_inc,
 			y_float,
@@ -298,9 +299,10 @@ int LMA_fit(
 			chi_square_percent);
 	*chi_square = (double) chi_square_float;
 
-	free(y_float);
-	free(sig_float);
-
+	if (y_float)
+		free(y_float);
+	if (sig_float)
+		free(sig_float);
 	if (instr_float) {
 		free(instr_float);
 	}
@@ -350,10 +352,10 @@ int LMA_fit(
 			param[7] = (double) param_float[6]; // tau3
 			break;
 	}
-
-	free(param_float);
-    
-	free(residuals_float);
+	if (param_float)
+		free(param_float);
+	if (residuals_float)
+		free(residuals_float);
 	GCI_ecf_free_matrix(covar_float);
 	GCI_ecf_free_matrix(alpha_float);
 	GCI_ecf_free_matrix(err_axes_float);

--- a/src/main/c/EcfWrapper.h
+++ b/src/main/c/EcfWrapper.h
@@ -38,20 +38,20 @@ extern "C" {
 #include "Ecf.h"
 
 int RLD_fit(
-        double x_inc,
-        double y[],
-        int fit_start,
-        int fit_end,
-        double instr[],
-        int n_instr,
-        noise_type noise,
-        double sig[],
-        double *z,
-        double *a,
-        double *tau,
-        double fitted[],
-        double *chi_square,
-        double chi_square_target
+     double x_inc,
+     double y[],
+     int fit_start,
+     int fit_end,
+     double instr[],
+     int n_instr,
+     int noise,//noise_type noise,
+     double sig[],
+     double *z,
+     double *a,
+     double *tau,
+     double fitted[],
+     double *chi_square,
+     double chi_square_target
         );
 
 int LMA_fit(
@@ -61,7 +61,7 @@ int LMA_fit(
         int fit_end,
         double instr[],
         int n_instr,
-        noise_type noise,
+     	int noise,//noise_type noise,
         double sig[],
         double param[],
         int param_free[],

--- a/src/main/c/loci_slim_SLIMCurve.c
+++ b/src/main/c/loci_slim_SLIMCurve.c
@@ -46,6 +46,11 @@ JNIEXPORT jint JNICALL Java_loci_slim_SLIMCurve_RLD_1fit
     jdouble *chi_square_ref;
     int return_value;
 
+    //Instead of crashing, return -1
+    if(y == NULL || z == NULL || a == NULL || tau == NULL || fitted == NULL || chi_square == NULL) {
+       return -1;
+    }
+
     // convert the arrays
     y_array = (*env)->GetDoubleArrayElements(env, y, 0);
     instr_array = NULL;
@@ -109,6 +114,11 @@ JNIEXPORT jint JNICALL Java_loci_slim_SLIMCurve_LMA_1fit
     jdouble *chi_square_ref;
     int return_value;
 
+
+    //Instead of crashing, return -1
+    if(y == NULL || param == NULL || param_free == NULL || fitted == NULL || chi_square == NULL) {
+       return -1;
+    }
     // convert the arrays
     y_array = (*env)->GetDoubleArrayElements(env, y, 0);
     instr_array = NULL;

--- a/src/main/java/loci/slim/SLIMCurve.java
+++ b/src/main/java/loci/slim/SLIMCurve.java
@@ -78,7 +78,7 @@ public class SLIMCurve {
 
 	static {
 		NarSystem.loadLibrary();
-		System.err.println("SLIM Curve loaded!");
+		//System.err.println("SLIM Curve loaded!");
 	}
 
 	/** Does the RLD fit with native library via JNI. */

--- a/src/main/java/loci/slim/SLIMCurve.java
+++ b/src/main/java/loci/slim/SLIMCurve.java
@@ -23,16 +23,12 @@
 
 package loci.slim;
 
-import org.scijava.nativelib.NativeLibraryUtil;
-
 /**
  * TODO
  * 
  * @author Aivar Grislis
  */
 public class SLIMCurve {
-
-	private static volatile boolean s_libraryLoaded = false;
 
 	/**
 	 * This supports calling the library using JNI.
@@ -80,12 +76,9 @@ public class SLIMCurve {
 		int paramFree[], int nParam, double fitted[], double chiSquare[],
 		double chiSquareTarget, double chiSquareDelta);
 
-	public SLIMCurve() {
-		// load platform-appropriate native library
-		s_libraryLoaded =
-			NativeLibraryUtil.loadVersionedNativeLibrary(this.getClass(),
-				"slim-curve");
-		System.out.println("SLIM Curve loaded " + s_libraryLoaded);
+	static {
+		NarSystem.loadLibrary();
+		System.err.println("SLIM Curve loaded!");
 	}
 
 	/** Does the RLD fit with native library via JNI. */

--- a/src/test/java/loci/slim/SLIMCurveTest.java
+++ b/src/test/java/loci/slim/SLIMCurveTest.java
@@ -1,0 +1,59 @@
+/*
+ * #%L
+ * SLIM Curve package for exponential curve fitting of spectral lifetime data.
+ * %%
+ * Copyright (C) 2010 - 2014 Gray Institute University of Oxford and Board of
+ * Regents of the University of Wisconsin-Madison.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
+package loci.slim;
+
+import org.junit.Test;
+
+/**
+ * Tests {@link SLIMCurve}.
+ * 
+ * @author Zach Petersen
+ */
+public class SLIMCurveTest {
+
+	static {
+		NarSystem.loadLibrary();
+	}
+
+	/** Tests {@link SLIMCurve#fitRLD}. */
+	@Test
+	public void testFitRLD() {
+//		final double xInc, final double y[], final int fitStart,
+//		final int fitEnd, final double instr[], final int nInstr, final int noise,
+//		final double sig[], final double z[], final double a[], final double tau[],
+//		final double fitted[], final double chiSquare[],
+//		final double chiSquareTarget)
+	}
+
+	/** Tests {@link SLIMCurve#fitLMA}. */
+	@Test
+	public void testFitLMA() {
+//		final double xInc, final double y[], final int fitStart,
+//		final int fitEnd, final double instr[], final int n_instr, final int noise,
+//		final double sig[], final double param[], final int paramFree[],
+//		final int nParam, final double fitted[], final double chiSquare[],
+//		final double chiSquareTarget, final double chiSquareDelta)
+	}
+
+}

--- a/src/test/java/loci/slim/SLIMCurveTest.java
+++ b/src/test/java/loci/slim/SLIMCurveTest.java
@@ -28,12 +28,13 @@ import static org.junit.Assert.*;
 import org.junit.Test;
 
 /**
- * Tests {@link SLIMCurve}.
+ * Tests {@link SLIMCurve}.  Test parameters currently based 
+ * off of values in files data.data and test.ini
  * 
  * @author Zach Petersen
  */
 public class SLIMCurveTest {
-	final double xInc = .048828;
+	final double xInc = 0.048828125; 
 	final double y[] = {
 			40.000000, 45.000000, 34.000000, 54.000000, 44.000000,
 			53.000000, 47.000000, 56.000000, 62.000000, 66.000000,
@@ -80,14 +81,14 @@ public class SLIMCurveTest {
 	final int fitStart = 10;
 	final int fitEnd = 203;
 	final double instr[] = {
-			0.009110,
-			0.038822,
-			0.131711,
-			0.252389,
-			0.277230,
-			0.180233,
-			0.079276,
-			0.031228
+			0.00911042001098394393920898437500000,
+			0.03882249817252159118652343750000000,
+			0.13171100616455078125000000000000000,
+			0.25238901376724243164062500000000000,
+			0.27722999453544616699218750000000000,
+			0.18023300170898437500000000000000000,
+			0.07927619665861129760742187500000000,
+			0.03122770041227340698242187500000000
 	};  
 	final int nInstr = 8;
 	final int noise = 5;
@@ -133,17 +134,17 @@ public class SLIMCurveTest {
 		SLIMCurve slimCurve = new SLIMCurve();
 		final int lma = slimCurve.fitLMA(xInc, y, fitStart, fitEnd, instr, nInstr, noise, sig, param, paramFree, nParam, fitted, chiSquare, chiSquareTarget, chiSquareDelta);
 		System.out.println("LMA estimate = " + lma);
-		System.out.println("A: " + param[1] + " Tau: " + param[2] + " Z: " + param[0] + " X^2: " + (chiSquare[0] / chi_sq_adjust));
-		int _lma = 17;
-		int _a = 11795;
+		System.out.println("A: " + param[2] + " Tau: " + param[3] + " Z: " + param[1] + " X^2: " + (chiSquare[0] / chi_sq_adjust));
+		int _lma = 58;
+		int _a = 10501;
 		int _tau = 2;
-		int _z = 105;
-		int _x2 = 414;
-//		assertEquals("rld value is not correct", _lma, lma);
-//		assertEquals("a value is not correct", _a, (int)a[0]);
-//		assertEquals("tau value is not correct", _tau, (int)tau[0]);
-//		assertEquals("z value is not correct", _z, (int)z[0]);
-//		assertEquals("Chi squared value is not correct", _x2, (int)chiSquare[0] / chi_sq_adjust);
+		int _z = -163;
+		int _x2 = 437;
+		assertEquals("lma value is not correct", _lma, lma);
+		assertEquals("a value is not correct", _a, (int)param[2]);
+		assertEquals("tau value is not correct", _tau, (int)param[3]);
+		assertEquals("z value is not correct", _z, (int)param[1]);
+		assertEquals("Chi squared value is not correct", _x2, (int)chiSquare[0] / chi_sq_adjust);
 	
 	}
 

--- a/src/test/java/loci/slim/SLIMCurveTest.java
+++ b/src/test/java/loci/slim/SLIMCurveTest.java
@@ -23,6 +23,8 @@
 
 package loci.slim;
 
+import static org.junit.Assert.*;
+
 import org.junit.Test;
 
 /**
@@ -31,7 +33,73 @@ import org.junit.Test;
  * @author Zach Petersen
  */
 public class SLIMCurveTest {
-
+	final double xInc = .048828;
+	final double y[] = {
+			40.000000, 45.000000, 34.000000, 54.000000, 44.000000,
+			53.000000, 47.000000, 56.000000, 62.000000, 66.000000,
+			82.000000, 90.000000, 108.000000, 122.000000, 323.000000,
+			1155.000000, 4072.000000, 8278.000000, 11919.000000, 13152.000000,
+			13071.000000, 12654.000000, 11946.000000, 11299.000000, 10859.000000,
+			10618.000000, 10045.000000, 9576.000000, 9208.000000, 9113.000000,
+			8631.000000, 8455.000000, 8143.000000, 8102.000000, 7672.000000,
+			7384.000000, 7463.000000, 7254.000000, 6980.000000, 6910.000000,
+			6411.000000, 6355.000000, 6083.000000, 5894.000000, 5880.000000,
+			5735.000000, 5528.000000, 5343.000000, 5224.000000, 4933.000000,
+			5026.000000, 4914.000000, 4845.000000, 4681.000000, 4426.000000,
+			4485.000000, 4271.000000, 4295.000000, 4183.000000, 3989.000000,
+			3904.000000, 3854.000000, 3801.000000, 3600.000000, 3595.000000,
+			3434.000000, 3457.000000, 3291.000000, 3280.000000, 3178.000000,
+			3132.000000, 2976.000000, 2973.000000, 2940.000000, 2770.000000,
+			2969.000000, 2851.000000, 2702.000000, 2677.000000, 2460.000000,
+			2536.000000, 2528.000000, 2347.000000, 2382.000000, 2380.000000,
+			2234.000000, 2251.000000, 2208.000000, 2115.000000, 2136.000000,
+			2000.000000, 2006.000000, 1970.000000, 1985.000000, 1886.000000,
+			1898.000000, 1884.000000, 1744.000000, 1751.000000, 1797.000000,
+			1702.000000, 1637.000000, 1547.000000, 1526.000000, 1570.000000,
+			1602.000000, 1557.000000, 1521.000000, 1417.000000, 1391.000000,
+			1332.000000, 1334.000000, 1290.000000, 1336.000000, 1297.000000,
+			1176.000000, 1189.000000, 1220.000000, 1209.000000, 1217.000000,
+			1140.000000, 1079.000000, 1059.000000, 1074.000000, 1061.000000,
+			1013.000000, 1075.000000, 1021.000000, 1012.000000, 940.000000,
+			982.000000, 866.000000, 881.000000, 901.000000, 883.000000,
+			893.000000, 845.000000, 819.000000, 831.000000, 758.000000,
+			794.000000, 779.000000, 772.000000, 779.000000, 791.000000,
+			729.000000, 732.000000, 687.000000, 690.000000, 698.000000,
+			661.000000, 647.000000, 668.000000, 642.000000, 619.000000,
+			629.000000, 656.000000, 579.000000, 579.000000, 600.000000,
+			563.000000, 584.000000, 531.000000, 554.000000, 526.000000,
+			484.000000, 530.000000, 515.000000, 493.000000, 502.000000,
+			479.000000, 445.000000, 439.000000, 466.000000, 431.000000,
+			423.000000, 451.000000, 412.000000, 415.000000, 393.000000,
+			404.000000, 390.000000, 398.000000, 352.000000, 394.000000,
+			376.000000, 338.000000, 377.000000, 367.000000, 355.000000,
+			352.000000, 375.000000, 339.000000, 347.000000, 316.000000,
+			295.000000, 322.000000, 311.000000, 294.000000, 304.000000,
+			264.000000, 293.000000, 294.000000, 283.000000 
+			}; 
+	final int fitStart = 10;
+	final int fitEnd = 203;
+	final double instr[] = {
+			0.009110,
+			0.038822,
+			0.131711,
+			0.252389,
+			0.277230,
+			0.180233,
+			0.079276,
+			0.031228
+	};  
+	final int nInstr = 8;
+	final int noise = 5;
+	final double sig[] = {}; 
+	final double z[]  = {0};
+	final double a[]  = {1000};
+	final double tau[] = {2};
+	final double fitted[] = {0};  
+	final double chiSquare[] = {0}; 
+	final double chiSquareTarget = 237.5;
+	final int chi_sq_adjust = fitEnd - fitStart - 3;
+	
 	static {
 		NarSystem.loadLibrary();
 	}
@@ -39,21 +107,44 @@ public class SLIMCurveTest {
 	/** Tests {@link SLIMCurve#fitRLD}. */
 	@Test
 	public void testFitRLD() {
-//		final double xInc, final double y[], final int fitStart,
-//		final int fitEnd, final double instr[], final int nInstr, final int noise,
-//		final double sig[], final double z[], final double a[], final double tau[],
-//		final double fitted[], final double chiSquare[],
-//		final double chiSquareTarget)
+		SLIMCurve slimCurve = new SLIMCurve();
+		final int rld = slimCurve.fitRLD(xInc, y, fitStart, fitEnd, instr, nInstr, noise, sig, z, a, tau, fitted, chiSquare, chiSquareTarget);
+		System.out.println("RLD estimate = " + rld);
+		System.out.println("A: " + a[0] + " Tau: " + tau[0] + " Z: " + z[0] + " X^2: " + (chiSquare[0] / chi_sq_adjust));
+		int _rld = 2;
+		int _a = 11823;
+		int _tau = 2;
+		int _z = 105;
+		int _x2 = 414;
+		assertEquals("rld value is not correct", _rld, rld);
+		assertEquals("a value is not correct", _a, (int)a[0]);
+		assertEquals("tau value is not correct", _tau, (int)tau[0]);
+		assertEquals("z value is not correct", _z, (int)z[0]);
+		assertEquals("Chi squared value is not correct", _x2, (int)chiSquare[0] / chi_sq_adjust);
 	}
 
 	/** Tests {@link SLIMCurve#fitLMA}. */
 	@Test
 	public void testFitLMA() {
-//		final double xInc, final double y[], final int fitStart,
-//		final int fitEnd, final double instr[], final int n_instr, final int noise,
-//		final double sig[], final double param[], final int paramFree[],
-//		final int nParam, final double fitted[], final double chiSquare[],
-//		final double chiSquareTarget, final double chiSquareDelta)
+		final double param[] = {chiSquare[0] / chi_sq_adjust, 0, 1000, 2}; //chi squared, z, a, tau
+		final int paramFree[] = {1, 1, 1};
+		final int nParam = 3;
+		final double chiSquareDelta = .01;
+		SLIMCurve slimCurve = new SLIMCurve();
+		final int lma = slimCurve.fitLMA(xInc, y, fitStart, fitEnd, instr, nInstr, noise, sig, param, paramFree, nParam, fitted, chiSquare, chiSquareTarget, chiSquareDelta);
+		System.out.println("LMA estimate = " + lma);
+		System.out.println("A: " + param[1] + " Tau: " + param[2] + " Z: " + param[0] + " X^2: " + (chiSquare[0] / chi_sq_adjust));
+		int _lma = 17;
+		int _a = 11795;
+		int _tau = 2;
+		int _z = 105;
+		int _x2 = 414;
+//		assertEquals("rld value is not correct", _lma, lma);
+//		assertEquals("a value is not correct", _a, (int)a[0]);
+//		assertEquals("tau value is not correct", _tau, (int)tau[0]);
+//		assertEquals("z value is not correct", _z, (int)z[0]);
+//		assertEquals("Chi squared value is not correct", _x2, (int)chiSquare[0] / chi_sq_adjust);
+	
 	}
 
 }


### PR DESCRIPTION
This PR allows for the native C library to be called in SLIMCurve.java using [NarSystem](https://github.com/maven-nar/nar-maven-plugin) instead of calling NativeLibraryUtil.  Some error checking has also been added for the JNI call.  Unit tests have also been implemented. 