### PR TITLE
Fix/clarify error codes from fitting engines.

### DIFF
--- a/src/main/c/BayesAnalysis.h
+++ b/src/main/c/BayesAnalysis.h
@@ -48,7 +48,7 @@ void Bayes_set_search_grid(float parammin[], float parammax[], int nparam);
 * \param[out] minuslogprob The resulting negated log probability (-log(P)) of the estimate.
 * \param[out] nphotons The total number of photons included in the fit.
 * \param[out] chisq The resulting raw chi squared value of the fit. To get the reduced chisq, divide by the degrees of freedom (fit_end - fit_start - nparam). Requires residuals array. Can be NULL if not required.
-* \return An error code, 0 = success.
+* \return A negative error code on failure, non-negative on success.
 */
 int Bayes_fitting_engine(/* Data in... */
                         float xincr,

--- a/src/main/c/Ecf.h
+++ b/src/main/c/Ecf.h
@@ -108,7 +108,7 @@ typedef struct _DMSPVAF {
  * \param[out] residuals An array containing the difference between the data and the fit.
  * \param[out] chisq The resulting raw chi squared value of the fit. To get the reduced chisq, divide by the degrees of freedom (fit_start - fit_end - nparam)
  * \param[in] chisq_target A raw chi squared value to aim for. If this value is reached fitting will stop. If you want to aim for a reduced chisq (say 1.1 or 1.0) you must multiply by the degree of freedom. (TRI2: "Try refits")
- * \return An error code, 0 = success.
+ * \return A negative error code on failure; non-negative on success.
  */
 int GCI_triple_integral_fitting_engine(float xincr, float y[], int fit_start, int fit_end,
 							  float instr[], int ninstr, noise_type noise, float sig[],
@@ -144,7 +144,7 @@ int GCI_triple_integral_fitting_engine(float xincr, float y[], int fit_start, in
  * \param[in] chisq_target A raw chi squared value to aim for. If this value is reached fitting will stop. If you want to aim for a reduced chisq (say 1.1 or 1.0) you must multiply by the degree of freedom. (TRI2: "Try refits")
  * \param[in] chisq_delta An individual fit will continue if the chisq value changes by more then this amount. Try 1E-5. (TRI2: "Stopping Criterion")
  * \param[in] chisq_percent Defines the confidence interval when calculating the error axes, e.g. 95 %.
- * \return An error code, 0 = success.
+ * \return A negative error code on failure; non-negative on success.
  */
 int GCI_marquardt_fitting_engine(float xincr, float *trans, int ndata, int fit_start, int fit_end, 
 						float instr[], int ninstr,

--- a/src/main/c/EcfSingle.c
+++ b/src/main/c/EcfSingle.c
@@ -274,7 +274,7 @@ int GCI_triple_integral_instr(float xincr, float y[],
 //			free(fitted_preconv);
 		if ((fitted_preconv = (float *) malloc((long unsigned int) fit_end * sizeof(float)))
 			== NULL)
-			return -3;
+			return -4;
 //		else
 //			fitted_preconv_size = fit_end;
 //	}
@@ -385,6 +385,7 @@ int GCI_triple_integral_fitting_engine(float xincr, float y[], int fit_start, in
 {
 	int tries=1, division=3;		 // the data
 	float local_chisq=3.0e38f, oldChisq=3.0e38f, oldZ, oldA, oldTau, *validFittedArray; // local_chisq a very high float but below oldChisq
+	int result = 0;
 
 	if (fitted==NULL)   // we require chisq but have not supplied a "fitted" array so must malloc one
 	{
@@ -394,8 +395,8 @@ int GCI_triple_integral_fitting_engine(float xincr, float y[], int fit_start, in
 
 	if (instr==NULL)           // no instrument/prompt has been supplied
 	{
-		GCI_triple_integral(xincr, y, fit_start, fit_end, noise, sig,
-								Z, A, tau, validFittedArray, residuals, &local_chisq, division);
+		result = GCI_triple_integral(xincr, y, fit_start, fit_end, noise, sig,
+				Z, A, tau, validFittedArray, residuals, &local_chisq, division);
 
 		while (local_chisq>chisq_target && (local_chisq<=oldChisq) && tries<MAXREFITS)
 		{
@@ -406,14 +407,14 @@ int GCI_triple_integral_fitting_engine(float xincr, float y[], int fit_start, in
 //			division++;
 			division+=division/3;
 			tries++;
-			GCI_triple_integral(xincr, y, fit_start, fit_end, noise, sig,
-								Z, A, tau, validFittedArray, residuals, &local_chisq, division);
+			result = GCI_triple_integral(xincr, y, fit_start, fit_end, noise, sig,
+					Z, A, tau, validFittedArray, residuals, &local_chisq, division);
 		}
 	}
 	else
 	{
-		GCI_triple_integral_instr(xincr, y, fit_start, fit_end, instr, ninstr, noise, sig,
-								Z, A, tau, validFittedArray, residuals, &local_chisq, division);
+		result = GCI_triple_integral_instr(xincr, y, fit_start, fit_end, instr, ninstr, noise, sig,
+				Z, A, tau, validFittedArray, residuals, &local_chisq, division);
 
 		while (local_chisq>chisq_target && (local_chisq<=oldChisq) && tries<MAXREFITS)
 		{
@@ -424,8 +425,8 @@ int GCI_triple_integral_fitting_engine(float xincr, float y[], int fit_start, in
 //			division++;
 			division+=division/3;
 			tries++;
-			GCI_triple_integral_instr(xincr, y, fit_start, fit_end, instr, ninstr, noise, sig,
-								Z, A, tau, validFittedArray, residuals, &local_chisq, division);
+			result = GCI_triple_integral_instr(xincr, y, fit_start, fit_end, instr, ninstr, noise, sig,
+					Z, A, tau, validFittedArray, residuals, &local_chisq, division);
 
 		}
 	}
@@ -445,7 +446,11 @@ int GCI_triple_integral_fitting_engine(float xincr, float y[], int fit_start, in
 		free (validFittedArray);
 	}
 
-	return(tries);
+	if (tries >= MAXREFITS)
+		return -5;
+	if (result < 0)
+		return result;
+	return tries;
 }
 
 /********************************************************************


### PR DESCRIPTION
Uniformly state that failure results in negative codes, and that success
is non-negative (not necessarily zero). This is backward-compatible
while eliminating the differences between the different algorithms.

Also modify `GCI_triple_integral_fitting_engine()` to propagate the error
code from `GCI_triple_integral()` or `GCI_triple_integral_instr()` upon
failure on the last retry, as well as return an error when the maximum
retries were attempted without success.

Finally, changes the return code on `malloc()` failure in
`GCI_triple_integral_instr()` to avoid clash with another error.

Closes #41.